### PR TITLE
Guard nil character data in XP and name helpers

### DIFF
--- a/DataStore_Characters/DataStore_Characters.lua
+++ b/DataStore_Characters/DataStore_Characters.lua
@@ -218,7 +218,7 @@ local function _GetCharacterClassColor(character)
 end
 
 local function _GetColoredCharacterName(character)
-	return format("%s%s", _GetCharacterClassColor(character), character.name)
+	return format("%s%s", _GetCharacterClassColor(character), character.name or "?")
 end
 
 local function _GetCharacterFaction(character)
@@ -282,7 +282,9 @@ local function _GetRestXP(character)
 end
 
 local function _GetXPRate(character)
-	return floor((_GetXP(character) / _GetXPMax(character)) * 100)
+	local xp, maxXP = _GetXP(character), _GetXPMax(character)
+	if not xp or not maxXP or maxXP == 0 then return 0 end
+	return floor((xp / maxXP) * 100)
 end
 
 local function _GetRestXPRate(character)
@@ -323,7 +325,9 @@ local function _GetRestXPRate(character)
 	local savedRate = 0
 	local xpMax = _GetXPMax(character)
 	local restXP = _GetRestXP(character)
-	
+
+	if not xpMax then return 0 end
+
 	local maxXP = xpMax * multiplier
 	if restXP then
 		rate = restXP / (maxXP / 100)


### PR DESCRIPTION
Characters that have not been logged into yet (or whose data was populated only by a guild roster scan) may have only `BaseInfo` set. Reading `XPInfo`/`XP`/`maxXP` or `character.name` then crashes:

- `_GetXPRate` and `_GetRestXPRate` perform arithmetic on nil values (the post-fresh-install crash report references `DataStore_Characters.lua:285`).
- `_GetColoredCharacterName` passes nil into `format("%s%s", ..., character.name)`.

Adds nil guards in all three: `_GetXPRate` returns 0 when XP data is missing, `_GetRestXPRate` returns 0 when `xpMax` is nil, `_GetColoredCharacterName` defaults missing names to `"?"`.

Fixes Thaoky/Altoholic_Retail#102 and Thaoky/Altoholic_Retail#74.